### PR TITLE
fix: moved "map" and "created on" columns in save to the right

### DIFF
--- a/overwatch-tac/main/client/src/pages/Saves.tsx
+++ b/overwatch-tac/main/client/src/pages/Saves.tsx
@@ -147,7 +147,7 @@ const Saves: React.FC = () => {
   const [showAuthModal, setShowAuthModal] = useState(false);
   const navigate = useNavigate();
 
-  const gridLayout = "1.5fr 1fr 1fr 1.5fr";
+  const gridLayout = "1fr 200px 100px 160px";
 
   useEffect(() => {
     checkAuthAndFetch();


### PR DESCRIPTION
allows better spacing for long strategy names that previously pushed them over and misaligned them. everything is lined nicely now :)