### PR TITLE
125 feat add a play by play feature into the tacmap & QoL additions

### DIFF
--- a/overwatch-tac/main/client/src/pages/TacMap.tsx
+++ b/overwatch-tac/main/client/src/pages/TacMap.tsx
@@ -3,9 +3,21 @@ import { supabase } from "../Supabase";
 import { useSearchParams } from "react-router-dom";
 import { useNavigate } from "react-router-dom";
 
+const tacMapStyles = `
+@keyframes mapCardPopIn {
+  0%   { opacity: 0; transform: translateY(30px) scale(0.92); }
+  60%  { transform: translateY(-4px) scale(1.02); }
+  100% { opacity: 1; transform: translateY(0) scale(1); }
+}
+@keyframes dragSelectPulse {
+  0%, 100% { opacity: 0.5; }
+  50% { opacity: 0.8; }
+}
+`;
+
 type Team = "ally" | "enemy";
 type GameMode = "Control" | "Escort" | "Hybrid" | "Push" | "Flashpoint" | "Clash" | "Assault";
-type ToolType = "select" | "pen" | "eraser";
+type ToolType = "select" | "pen" | "eraser" | "line" | "arrow" | "circle";
 
 interface MapData {
   map_id: number;
@@ -37,9 +49,18 @@ interface DrawingLine {
   points: { x: number; y: number }[];
   color: string;
   width: number;
+  hasArrow?: boolean;
+  isCircle?: boolean;
 }
 
 interface HistoryState {
+  markers: Marker[];
+  drawings: DrawingLine[];
+}
+
+interface PlayStep {
+  id: number;
+  label: string;
   markers: Marker[];
   drawings: DrawingLine[];
 }
@@ -108,7 +129,7 @@ const ToolButton: React.FC<ToolButtonProps> = ({ name, icon, activeTool, onClick
       disabled={disabled}
       title={title}
       style={{
-        width: "50px", height: "50px", borderRadius: "8px", border: "none",
+        width: "40px", height: "40px", borderRadius: "8px", border: "none",
         background: isActive ? "linear-gradient(45deg, #e60082, #f65dfb)" : "#333",
         color: "white", cursor: disabled ? "not-allowed" : "pointer",
         display: "flex", justifyContent: "center", alignItems: "center", 
@@ -118,7 +139,7 @@ const ToolButton: React.FC<ToolButtonProps> = ({ name, icon, activeTool, onClick
         opacity: disabled ? 0.5 : 1
       }}
     >
-      <div style={{ width: "24px", height: "24px", display: "flex", alignItems: "center", justifyContent: "center" }}>
+      <div style={{ width: "20px", height: "20px", display: "flex", alignItems: "center", justifyContent: "center" }}>
         {icon}
       </div>
     </button>
@@ -134,6 +155,9 @@ const EraserIcon = () => (<svg width="24" height="24" viewBox="0 0 24 24" fill="
 const UndoIcon = () => (<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M3 7v6h6"/><path d="M21 17a9 9 0 0 0-15.5-6L3 13"/></svg>);
 const RedoIcon = () => (<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M21 7v6h-6"/><path d="M3 17a9 9 0 0 1 15.5-6L21 13"/></svg>);
 const TrashIcon = () => (<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M3 6h18"/><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/></svg>);
+const LineIcon = () => (<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round"><line x1="5" y1="19" x2="19" y2="5"/><circle cx="5" cy="19" r="2" fill="currentColor" stroke="none"/><circle cx="19" cy="5" r="2" fill="currentColor" stroke="none"/></svg>);
+const ArrowIcon = () => (<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><line x1="5" y1="19" x2="19" y2="5"/><polyline points="9 5 19 5 19 15"/></svg>);
+const CircleIcon = () => (<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round"><circle cx="12" cy="12" r="9"/></svg>);
 
 const TacMap: React.FC = () => {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -157,6 +181,33 @@ const TacMap: React.FC = () => {
   
   const [activeTool, setActiveTool] = useState<ToolType | null>(null);
   const [brushSize, setBrushSize] = useState<number>(4);
+  const [drawColor, setDrawColor] = useState<string>("#007bff");
+  const [isAnimating, setIsAnimating] = useState(false);
+
+  // Drag-select refs so handlers always see current value
+  const [dragSelectStart, setDragSelectStartState] = useState<{x: number, y: number} | null>(null);
+  const dragSelectStartRef = useRef<{x: number, y: number} | null>(null);
+  const setDragSelectStart = (v: {x: number, y: number} | null) => { dragSelectStartRef.current = v; setDragSelectStartState(v); };
+  const justFinishedDragSelect = useRef(false);
+  const [dragSelectRect, setDragSelectRect] = useState<{x1: number, y1: number, x2: number, y2: number} | null>(null);
+  const [selectedMarkerIds, setSelectedMarkerIds] = useState<number[]>([]);
+  const [isDragSelectingGroup, setIsDragSelectingGroup] = useState(false);
+  const [groupDragStart, setGroupDragStart] = useState<{x: number, y: number} | null>(null);
+  const [groupOriginalPositions, setGroupOriginalPositions] = useState<{id: number, x: number, y: number}[]>([]);
+
+  // Line tool
+  const [lineStart, setLineStartState] = useState<{x: number, y: number} | null>(null);
+  const lineStartRef = useRef<{x: number, y: number} | null>(null);
+  const setLineStart = (v: {x: number, y: number} | null) => { lineStartRef.current = v; setLineStartState(v); };
+  const [linePreview, setLinePreview] = useState<{x: number, y: number} | null>(null);
+
+  // Circle tool
+  const [circleStart, setCircleStartState] = useState<{x: number, y: number} | null>(null);
+  const circleStartRef = useRef<{x: number, y: number} | null>(null);
+  const setCircleStart = (v: {x: number, y: number} | null) => { circleStartRef.current = v; setCircleStartState(v); };
+  const [circlePreview, setCirclePreview] = useState<{x: number, y: number} | null>(null);
+
+  const [modeAnimKey, setModeAnimKey] = useState(0);
   const [selectedElement, setSelectedElement] = useState<{ type: "marker" | "drawing"; id: number } | null>(null);
   const [isDraggingElement, setIsDraggingElement] = useState(false);
   const [dragStartCoords, setDragStartCoords] = useState<{x: number, y: number} | null>(null);
@@ -186,9 +237,20 @@ const TacMap: React.FC = () => {
   const [hoveredMap, setHoveredMap] = useState<MapData | null>(null);
   const [isMapButtonHovered, setIsMapButtonHovered] = useState(false);
 
+  // Play-by-play
+  const [playSteps, setPlaySteps] = useState<PlayStep[]>([]);
+  const [currentStepIndex, setCurrentStepIndex] = useState<number | null>(null);
+  const [isPlayByPlayOpen, setIsPlayByPlayOpen] = useState(false);
+
   const mapRef = useRef<HTMLDivElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const internalMapRef = useRef<HTMLDivElement>(null);
+  const markersRef = useRef<Marker[]>([]);
+  const drawingsRef = useRef<DrawingLine[]>([]);
+
+  // Keep refs in sync with state
+  useEffect(() => { markersRef.current = markers; }, [markers]);
+  useEffect(() => { drawingsRef.current = drawings; }, [drawings]);
 
   const allyMarkers = useMemo(() => markers.filter(m => m.team === "ally"), [markers]);
   const enemyMarkers = useMemo(() => markers.filter(m => m.team === "enemy"), [markers]);
@@ -216,6 +278,10 @@ const TacMap: React.FC = () => {
   }, [selectedMap]);
 
   useEffect(() => {
+    if (selectedMode) setModeAnimKey(k => k + 1);
+  }, [selectedMode]);
+
+  useEffect(() => {
     if (loadId && mapList.length > 0 && heroAssets.length > 0 && !isDataLoaded) {
       loadSavedStrategy(loadId);
       setIsDataLoaded(true);
@@ -224,7 +290,7 @@ const TacMap: React.FC = () => {
 
   useEffect(() => {
     drawCanvas();
-  }, [drawings, selectedElement, activeTool, mousePos, brushSize, isSlidingBrush]);
+  }, [drawings, selectedElement, activeTool, mousePos, brushSize, isSlidingBrush, linePreview, lineStart, circlePreview, circleStart, dragSelectRect, selectedMarkerIds]);
 
   const pushToHistory = (newMarkers: Marker[], newDrawings: DrawingLine[]) => {
     const nextState = { markers: newMarkers, drawings: newDrawings };
@@ -258,6 +324,11 @@ const TacMap: React.FC = () => {
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setLineStart(null); setLinePreview(null);
+        setCircleStart(null); setCirclePreview(null);
+        setDragSelectStart(null); setDragSelectRect(null);
+      }
       if (e.key === ' ' && !(e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement)) {
         e.preventDefault();
         setSpacePressed(true);
@@ -274,12 +345,13 @@ const TacMap: React.FC = () => {
         e.preventDefault();
         handleRedo();
       } else if (e.key === 'Delete' || e.key === 'Backspace') {
-        if (selectedElement) { e.preventDefault(); deleteSelectedElement(); }
+        if (selectedElement || selectedMarkerIds.length > 0) { e.preventDefault(); deleteSelectedElement(); }
       } else if (!modifier && selectedMap) {
         switch (e.key.toLowerCase()) {
           case 's': setActiveTool('select'); break;
           case 'p': setActiveTool('pen'); break;
           case 'e': setActiveTool('eraser'); break;
+          case 'l': setActiveTool('line'); setLineStart(null); setLinePreview(null); break;
           default: break;
         }
       }
@@ -295,7 +367,7 @@ const TacMap: React.FC = () => {
       window.removeEventListener("keydown", handleKeyDown);
       window.removeEventListener("keyup", handleKeyUp);
     };
-  }, [historyIndex, history, selectedElement, selectedMap]);
+  }, [historyIndex, history, selectedElement, selectedMarkerIds, selectedMap]);
 
   const drawCanvas = () => {
     const canvas = canvasRef.current;
@@ -307,22 +379,70 @@ const TacMap: React.FC = () => {
     ctx.lineCap = "round";
     ctx.lineJoin = "round";
 
-    drawings.forEach(drawing => {
-      if (drawing.points.length < 2) return;
+    const drawArrowhead = (ctx: CanvasRenderingContext2D, x1: number, y1: number, x2: number, y2: number, width: number, color: string) => {
+      const angle = Math.atan2(y2 - y1, x2 - x1);
+      const headLen = Math.max(12, width * 3.5);
+      const headAngle = Math.PI / 6;
+      ctx.save();
+      ctx.fillStyle = color;
+      ctx.strokeStyle = color;
+      ctx.lineWidth = width;
       ctx.beginPath();
-      ctx.moveTo(drawing.points[0].x, drawing.points[0].y);
-      let i;
-      for (i = 1; i < drawing.points.length - 2; i++) {
-        const xc = (drawing.points[i].x + drawing.points[i + 1].x) / 2;
-        const yc = (drawing.points[i].y + drawing.points[i + 1].y) / 2;
-        ctx.quadraticCurveTo(drawing.points[i].x, drawing.points[i].y, xc, yc);
+      ctx.moveTo(x2, y2);
+      ctx.lineTo(x2 - headLen * Math.cos(angle - headAngle), y2 - headLen * Math.sin(angle - headAngle));
+      ctx.lineTo(x2 - headLen * Math.cos(angle + headAngle), y2 - headLen * Math.sin(angle + headAngle));
+      ctx.closePath();
+      ctx.fill();
+      ctx.restore();
+    };
+
+    drawings.forEach(drawing => {
+      if (drawing.isCircle) {
+        if (drawing.points.length < 2) return;
+        const [p1, p2] = drawing.points;
+        const cx = (p1.x + p2.x) / 2;
+        const cy = (p1.y + p2.y) / 2;
+        const rx = Math.abs(p2.x - p1.x) / 2;
+        const ry = Math.abs(p2.y - p1.y) / 2;
+        ctx.beginPath();
+        ctx.ellipse(cx, cy, rx, ry, 0, 0, Math.PI * 2);
+        ctx.strokeStyle = drawing.color;
+        ctx.lineWidth = drawing.width;
+        ctx.stroke();
+      } else {
+        if (drawing.points.length < 2) return;
+        ctx.beginPath();
+        ctx.moveTo(drawing.points[0].x, drawing.points[0].y);
+        const isStraightLine = drawing.points.length === 2;
+        if (isStraightLine) {
+          ctx.lineTo(drawing.points[1].x, drawing.points[1].y);
+          ctx.strokeStyle = drawing.color;
+          ctx.lineWidth = drawing.width;
+          // line and arrow tools use dashed style matching the pen's aesthetic
+          ctx.setLineDash([drawing.width * 2.5, drawing.width * 1.5]);
+          ctx.stroke();
+          ctx.setLineDash([]);
+        } else {
+          let i;
+          for (i = 1; i < drawing.points.length - 2; i++) {
+            const xc = (drawing.points[i].x + drawing.points[i + 1].x) / 2;
+            const yc = (drawing.points[i].y + drawing.points[i + 1].y) / 2;
+            ctx.quadraticCurveTo(drawing.points[i].x, drawing.points[i].y, xc, yc);
+          }
+          if (i < drawing.points.length - 1) {
+            ctx.quadraticCurveTo(drawing.points[i].x, drawing.points[i].y, drawing.points[i + 1].x, drawing.points[i + 1].y);
+          }
+          ctx.strokeStyle = drawing.color;
+          ctx.lineWidth = drawing.width;
+          ctx.stroke();
+        }
+
+        if (drawing.hasArrow && drawing.points.length >= 2) {
+          const last = drawing.points[drawing.points.length - 1];
+          const prev = drawing.points[drawing.points.length - 2];
+          drawArrowhead(ctx, prev.x, prev.y, last.x, last.y, drawing.width, drawing.color);
+        }
       }
-      if (i < drawing.points.length - 1) {
-         ctx.quadraticCurveTo(drawing.points[i].x, drawing.points[i].y, drawing.points[i + 1].x, drawing.points[i + 1].y);
-      }
-      ctx.strokeStyle = drawing.color;
-      ctx.lineWidth = drawing.width;
-      ctx.stroke();
 
       if (selectedElement?.type === "drawing" && selectedElement.id === drawing.id) {
         const xs = drawing.points.map(p => p.x);
@@ -348,6 +468,55 @@ const TacMap: React.FC = () => {
       ctx.stroke();
       ctx.fillStyle = "rgba(246, 93, 251, 0.15)";
       ctx.fill();
+    }
+
+    // Line / Arrow tool preview
+    if ((activeTool === "line" || activeTool === "arrow") && lineStartRef.current && linePreview) {
+      ctx.beginPath();
+      ctx.moveTo(lineStartRef.current.x, lineStartRef.current.y);
+      ctx.lineTo(linePreview.x, linePreview.y);
+      ctx.strokeStyle = drawColor;
+      ctx.lineWidth = brushSize;
+      ctx.setLineDash([6, 4]);
+      ctx.stroke();
+      ctx.setLineDash([]);
+      ctx.beginPath(); ctx.arc(lineStartRef.current.x, lineStartRef.current.y, brushSize / 2 + 2, 0, Math.PI * 2);
+      ctx.fillStyle = drawColor; ctx.fill();
+      ctx.beginPath(); ctx.arc(linePreview.x, linePreview.y, brushSize / 2 + 2, 0, Math.PI * 2);
+      ctx.fill();
+      if (activeTool === "arrow") {
+        drawArrowhead(ctx, lineStartRef.current.x, lineStartRef.current.y, linePreview.x, linePreview.y, brushSize, drawColor);
+      }
+    }
+
+    // Circle tool preview
+    if (activeTool === "circle" && circleStartRef.current && circlePreview) {
+      const p1 = circleStartRef.current;
+      const p2 = circlePreview;
+      const cx = (p1.x + p2.x) / 2;
+      const cy = (p1.y + p2.y) / 2;
+      const rx = Math.abs(p2.x - p1.x) / 2;
+      const ry = Math.abs(p2.y - p1.y) / 2;
+      ctx.beginPath();
+      ctx.ellipse(cx, cy, rx, ry, 0, 0, Math.PI * 2);
+      ctx.strokeStyle = drawColor;
+      ctx.lineWidth = brushSize;
+      ctx.setLineDash([6, 4]);
+      ctx.stroke();
+      ctx.setLineDash([]);
+    }
+
+    // Drag-select rectangle
+    if (dragSelectRect) {
+      const { x1, y1, x2, y2 } = dragSelectRect;
+      ctx.save();
+      ctx.strokeStyle = "#f65dfb";
+      ctx.lineWidth = 1.5;
+      ctx.setLineDash([5, 3]);
+      ctx.strokeRect(Math.min(x1,x2), Math.min(y1,y2), Math.abs(x2-x1), Math.abs(y2-y1));
+      ctx.fillStyle = "rgba(246, 93, 251, 0.08)";
+      ctx.fillRect(Math.min(x1,x2), Math.min(y1,y2), Math.abs(x2-x1), Math.abs(y2-y1));
+      ctx.restore();
     }
   };
 
@@ -380,7 +549,18 @@ const TacMap: React.FC = () => {
         let loadedDrawings: DrawingLine[] = [];
         const { data: drawing } = await supabase.from("Map_Drawings").select("path").eq("save_id", id).maybeSingle();
         if (drawing?.path) {
-          try { loadedDrawings = JSON.parse(drawing.path); setDrawings(loadedDrawings); } catch(e) { console.error("Parse fail"); }
+          try {
+            const parsed = JSON.parse(drawing.path);
+            // New format: { drawings: [...], playSteps: [...] }
+            if (parsed && typeof parsed === "object" && !Array.isArray(parsed) && parsed.drawings) {
+              loadedDrawings = parsed.drawings;
+              if (parsed.playSteps) setPlaySteps(parsed.playSteps);
+            } else {
+              // Old format: plain array
+              loadedDrawings = parsed;
+            }
+            setDrawings(loadedDrawings);
+          } catch(e) { console.error("Parse fail"); }
         }
         setHistory([{ markers: loadedMarkers, drawings: loadedDrawings }]);
         setHistoryIndex(0);
@@ -434,7 +614,8 @@ const TacMap: React.FC = () => {
       }
 
       await supabase.from("Map_Drawings").upsert({
-        save_id: currentId, path: JSON.stringify(drawings),
+        save_id: currentId,
+        path: JSON.stringify({ drawings, playSteps }),
         color: activeTeam === "ally" ? "#007bff" : "#dc3545", width: brushSize
       }, { onConflict: 'save_id' });
       setIsConfirmModalOpen(true);
@@ -446,7 +627,73 @@ const TacMap: React.FC = () => {
     setSelectedElement(null); setSearchParams({}, { replace: true });
     setIsResetModalOpen(false); setHistory([{ markers: [], drawings: [] }]);
     setHistoryIndex(0); setZoom(1); setPan({ x: 0, y: 0 });
+    setPlaySteps([]); setCurrentStepIndex(null); setIsPlayByPlayOpen(false);
   };
+
+  // --- Play-by-play helpers ---
+  const addPlayStep = () => {
+    const newStep: PlayStep = {
+      id: Date.now(),
+      label: `Step ${playSteps.length + 1}`,
+      markers: markers.map(m => ({ ...m })),
+      drawings: drawings.map(d => ({ ...d, points: d.points.map(p => ({ ...p })) })),
+    };
+    const newSteps = [...playSteps, newStep];
+    setPlaySteps(newSteps);
+    setCurrentStepIndex(newSteps.length - 1);
+    setIsPlayByPlayOpen(true);
+  };
+
+  const goToStep = (index: number) => {
+    // Save current edits back into current step before navigating
+    if (currentStepIndex !== null) {
+      setPlaySteps(prev => prev.map((s, i) =>
+        i === currentStepIndex
+          ? { ...s, markers: markers.map(m => ({ ...m })), drawings: drawings.map(d => ({ ...d, points: d.points.map(p => ({ ...p })) })) }
+          : s
+      ));
+    }
+    const step = playSteps[index];
+    setIsAnimating(true);
+    setMarkers(step.markers.map(m => ({ ...m })));
+    setDrawings(step.drawings.map(d => ({ ...d, points: d.points.map(p => ({ ...p })) })));
+    setHistory([{ markers: step.markers, drawings: step.drawings }]);
+    setHistoryIndex(0);
+    setSelectedElement(null);
+    setCurrentStepIndex(index);
+    setTimeout(() => setIsAnimating(false), 600);
+  };
+
+  const deletePlayStep = (index: number) => {
+    const newSteps = playSteps.filter((_, i) => i !== index);
+    setPlaySteps(newSteps);
+    if (newSteps.length === 0) {
+      setCurrentStepIndex(null);
+    } else {
+      const newIndex = Math.min(index, newSteps.length - 1);
+      const step = newSteps[newIndex];
+      setMarkers(step.markers.map(m => ({ ...m })));
+      setDrawings(step.drawings.map(d => ({ ...d, points: d.points.map(p => ({ ...p })) })));
+      setHistory([{ markers: step.markers, drawings: step.drawings }]);
+      setHistoryIndex(0);
+      setSelectedElement(null);
+      setCurrentStepIndex(newIndex);
+    }
+  };
+
+  const renamePlayStep = (index: number, label: string) => {
+    setPlaySteps(prev => prev.map((s, i) => i === index ? { ...s, label } : s));
+  };
+
+  // Sync current step's state when markers/drawings change while in a step
+  useEffect(() => {
+    if (currentStepIndex === null) return;
+    setPlaySteps(prev => prev.map((s, i) =>
+      i === currentStepIndex
+        ? { ...s, markers: markers.map(m => ({ ...m })), drawings: drawings.map(d => ({ ...d, points: d.points.map(p => ({ ...p })) })) }
+        : s
+    ));
+  }, [markers, drawings]);
 
   const handleDrop = (e: React.DragEvent) => {
     e.preventDefault();
@@ -468,21 +715,41 @@ const TacMap: React.FC = () => {
   };
 
   const deleteSelectedElement = () => {
-    if (!selectedElement) return;
     let nextMarkers = [...markers];
     let nextDrawings = [...drawings];
-    if (selectedElement.type === "marker") {
-      nextMarkers = markers.filter(m => m.id !== selectedElement.id);
+    if (selectedMarkerIds.length > 0) {
+      nextMarkers = markers.filter(m => !selectedMarkerIds.includes(m.id));
       setMarkers(nextMarkers);
-    } else if (selectedElement.type === "drawing") {
-      nextDrawings = drawings.filter(d => d.id !== selectedElement.id);
-      setDrawings(nextDrawings);
+      setSelectedMarkerIds([]);
+    } else if (selectedElement) {
+      if (selectedElement.type === "marker") {
+        nextMarkers = markers.filter(m => m.id !== selectedElement.id);
+        setMarkers(nextMarkers);
+      } else if (selectedElement.type === "drawing") {
+        nextDrawings = drawings.filter(d => d.id !== selectedElement.id);
+        setDrawings(nextDrawings);
+      }
+      setSelectedElement(null);
+    } else {
+      return;
     }
     pushToHistory(nextMarkers, nextDrawings);
-    setSelectedElement(null);
   };
 
   const isPointNearLine = (px: number, py: number, line: DrawingLine): boolean => {
+    if (line.isCircle && line.points.length >= 2) {
+      const [p1, p2] = line.points;
+      const cx = (p1.x + p2.x) / 2;
+      const cy = (p1.y + p2.y) / 2;
+      const rx = Math.abs(p2.x - p1.x) / 2;
+      const ry = Math.abs(p2.y - p1.y) / 2;
+      if (rx === 0 || ry === 0) return false;
+      const nx = (px - cx) / rx;
+      const ny = (py - cy) / ry;
+      const dist = Math.sqrt(nx * nx + ny * ny);
+      const threshold = (line.width + 8) / Math.min(rx, ry);
+      return Math.abs(dist - 1) < threshold;
+    }
     const threshold = line.width + 5;
     for (let i = 0; i < line.points.length - 1; i++) {
       const x1 = line.points[i].x, y1 = line.points[i].y;
@@ -501,25 +768,6 @@ const TacMap: React.FC = () => {
     return false;
   };
 
-  const handleMapClick = (e: React.MouseEvent) => {
-    if (e.button === 2 || !selectedMap || spacePressed || isPanning) return;
-    const { x, y } = getCoords(e);
-    if (activeTool === "select") {
-      const clickedMarker = markers.find(m => Math.sqrt((m.x - x)**2 + (m.y - y)**2) < 25);
-      if (clickedMarker) { setSelectedElement({ type: "marker", id: clickedMarker.id }); return; }
-      const clickedDrawing = drawings.find(d => isPointNearLine(x, y, d));
-      if (clickedDrawing) { setSelectedElement({ type: "drawing", id: clickedDrawing.id }); return; }
-      setSelectedElement(null);
-    }
-    if (activeTool === "eraser") {
-      const lineToErase = drawings.find(d => isPointNearLine(x, y, d));
-      if (lineToErase) {
-        const nextDrawings = drawings.filter(d => d.id !== lineToErase.id);
-        setDrawings(nextDrawings); pushToHistory(markers, nextDrawings);
-      }
-    }
-  };
-
   const handleMouseDown = (e: React.MouseEvent) => {
     if (!selectedMap) return;
     if (spacePressed || e.button === 1 || e.button === 2) {
@@ -530,24 +778,72 @@ const TacMap: React.FC = () => {
       setIsDrawing(true);
       const newLine: DrawingLine = {
         id: Date.now(), points: [{ x, y }],
-        color: activeTeam === "ally" ? "#007bff" : "#dc3545", width: brushSize
+        color: drawColor, width: brushSize
       };
       setDrawings(prev => [...prev, newLine]);
       return;
     }
-    if (activeTool === "select") {
-      const clickedMarker = markers.find(m => Math.sqrt((m.x - x)**2 + (m.y - y)**2) < 25);
-      if (clickedMarker) {
-        setIsDraggingElement(true);
-        setSelectedElement({ type: "marker", id: clickedMarker.id });
-        return;
+    if (activeTool === "line" || activeTool === "arrow") {
+      if (!lineStartRef.current) {
+        // First click — set start point
+        setLineStart({ x, y });
+        setLinePreview({ x, y });
+      } else {
+        // Second click — commit the line
+        const newLine: DrawingLine = {
+          id: Date.now(), points: [lineStartRef.current, { x, y }],
+          color: drawColor, width: brushSize,
+          hasArrow: activeTool === "arrow"
+        };
+        setLineStart(null);
+        setLinePreview(null);
+        setDrawings(prev => {
+          const next = [...prev, newLine];
+          drawingsRef.current = next;
+          return next;
+        });
+        // push to history after state settles
+        setTimeout(() => pushToHistory(markersRef.current, drawingsRef.current), 0);
       }
-      const clickedDrawing = drawings.find(d => isPointNearLine(x, y, d));
+      return;
+    }
+    if (activeTool === "circle") {
+      if (!circleStartRef.current) {
+        setCircleStart({ x, y });
+        setCirclePreview({ x, y });
+      } else {
+        const newCircle: DrawingLine = {
+          id: Date.now(), points: [circleStartRef.current, { x, y }],
+          color: drawColor, width: brushSize, isCircle: true
+        };
+        setCircleStart(null);
+        setCirclePreview(null);
+        setDrawings(prev => {
+          const next = [...prev, newCircle];
+          drawingsRef.current = next;
+          return next;
+        });
+        setTimeout(() => pushToHistory(markersRef.current, drawingsRef.current), 0);
+      }
+      return;
+    }
+    if (activeTool === "select") {
+      const clickedMarker = markersRef.current.find(m => Math.sqrt((m.x - x)**2 + (m.y - y)**2) < 25);
+      if (clickedMarker) return; // handled by the marker div's onMouseDown
+      const clickedDrawing = drawingsRef.current.find(d => isPointNearLine(x, y, d));
       if (clickedDrawing) {
-        setIsDraggingElement(true); setDragStartCoords({ x, y });
+        setSelectedMarkerIds([]);
+        setIsDraggingElement(true);
+        setDragStartCoords({ x, y });
         setOriginalPoints(clickedDrawing.points.map(p => ({ ...p })));
         setSelectedElement({ type: "drawing", id: clickedDrawing.id });
+        return;
       }
+      // Empty area — start drag-select
+      setSelectedElement(null);
+      setSelectedMarkerIds([]);
+      setDragSelectStart({ x, y });
+      setDragSelectRect({ x1: x, y1: y, x2: x, y2: y });
     }
   };
 
@@ -559,6 +855,14 @@ const TacMap: React.FC = () => {
       setPan(prev => ({ x: prev.x + e.movementX, y: prev.y + e.movementY }));
       return;
     }
+    if ((activeTool === "line" || activeTool === "arrow") && lineStartRef.current) {
+      setLinePreview({ x, y });
+      return;
+    }
+    if (activeTool === "circle" && circleStartRef.current) {
+      setCirclePreview({ x, y });
+      return;
+    }
     if (isDrawing && activeTool === "pen") {
       setDrawings(prev => {
         const updated = [...prev];
@@ -566,6 +870,25 @@ const TacMap: React.FC = () => {
         lastLine.points = [...lastLine.points, { x, y }];
         return updated;
       });
+      return;
+    }
+    // Drag-select rect update
+    if (dragSelectStartRef.current && activeTool === "select") {
+      const ds = dragSelectStartRef.current;
+      setDragSelectRect({ x1: ds.x, y1: ds.y, x2: x, y2: y });
+      const x1 = Math.min(ds.x, x), x2 = Math.max(ds.x, x);
+      const y1 = Math.min(ds.y, y), y2 = Math.max(ds.y, y);
+      const inside = markersRef.current.filter(m => m.x >= x1 && m.x <= x2 && m.y >= y1 && m.y <= y2).map(m => m.id);
+      setSelectedMarkerIds(inside);
+      return;
+    }
+    // Group drag
+    if (isDragSelectingGroup && groupDragStart) {
+      const dx = x - groupDragStart.x, dy = y - groupDragStart.y;
+      setMarkers(prev => prev.map(m => {
+        const orig = groupOriginalPositions.find(o => o.id === m.id);
+        return orig ? { ...m, x: orig.x + dx, y: orig.y + dy } : m;
+      }));
       return;
     }
     if (isDraggingElement && selectedElement) {
@@ -580,10 +903,44 @@ const TacMap: React.FC = () => {
     }
   };
 
-  const handleMouseUp = () => {
+  const handleMouseUp = (e: React.MouseEvent) => {
     if (isPanning) { setIsPanning(false); return; }
+    // Commit drag-select — release mouse to finalise selection
+    if (dragSelectStartRef.current && activeTool === "select") {
+      justFinishedDragSelect.current = true;
+      setDragSelectStart(null);
+      setDragSelectRect(null);
+      return;
+    }
+    if (isDragSelectingGroup) {
+      pushToHistory(markers, drawings);
+      setIsDragSelectingGroup(false);
+      setGroupDragStart(null);
+      return;
+    }
     if ((isDrawing && activeTool === "pen") || (isDraggingElement && selectedElement)) { pushToHistory(markers, drawings); }
     setIsDrawing(false); setIsDraggingElement(false); setDragStartCoords(null);
+  };
+
+  const handleMapClick = (e: React.MouseEvent) => {
+    if (e.button === 2 || !selectedMap || spacePressed || isPanning) return;
+    const { x, y } = getCoords(e);
+    if (activeTool === "line" || activeTool === "arrow" || activeTool === "circle") return; // handled entirely in mouseDown
+    if (activeTool === "select") {
+      if (justFinishedDragSelect.current) { justFinishedDragSelect.current = false; return; }
+      const clickedMarker = markersRef.current.find(m => Math.sqrt((m.x - x)**2 + (m.y - y)**2) < 25);
+      if (clickedMarker) { setSelectedElement({ type: "marker", id: clickedMarker.id }); setSelectedMarkerIds([]); return; }
+      const clickedDrawing = drawingsRef.current.find(d => isPointNearLine(x, y, d));
+      if (clickedDrawing) { setSelectedElement({ type: "drawing", id: clickedDrawing.id }); setSelectedMarkerIds([]); return; }
+      setSelectedElement(null); setSelectedMarkerIds([]);
+    }
+    if (activeTool === "eraser") {
+      const lineToErase = drawingsRef.current.find(d => isPointNearLine(x, y, d));
+      if (lineToErase) {
+        const nextDrawings = drawingsRef.current.filter(d => d.id !== lineToErase.id);
+        setDrawings(nextDrawings); pushToHistory(markersRef.current, nextDrawings);
+      }
+    }
   };
 
   const handleWheel = (e: React.WheelEvent) => {
@@ -598,10 +955,11 @@ const TacMap: React.FC = () => {
     });
   };
 
-  const filteredMaps = mapList.filter(m => m.map_type?.toLowerCase() === selectedMode?.toLowerCase());
+  const filteredMaps = mapList.filter(m => m.map_type?.toLowerCase() === selectedMode?.toLowerCase()).sort((a, b) => a.name.localeCompare(b.name));
 
   return (
     <div style={{ color: "white", backgroundColor: "#111", position: "fixed", top: "60px", left: 0, height: "calc(100vh - 60px)", width: "100vw", display: "flex", overflow: "hidden", zIndex: 50 }}>
+      <style>{tacMapStyles}</style>
       <div style={{ 
         width: sidebarOpen ? "350px" : "0px", background: "#161616", 
         borderRight: sidebarOpen ? "1px solid #282828" : "none", display: "flex", 
@@ -639,7 +997,7 @@ const TacMap: React.FC = () => {
             <textarea value={description} onChange={(e) => setDescription(e.target.value)} style={{ width: "100%", height: "60px", background: "#111", color: "white", border: "1px solid #444", borderRadius: "4px", padding: "10px", resize: "none" }} />
           </div>
 
-          <div style={{ background: "#222", padding: "15px", borderRadius: "8px", border: "1px solid #444", opacity: selectedMap ? 1 : 0.5, pointerEvents: selectedMap ? "auto" : "none", display: "flex", flexDirection: "column", maxHeight: "380px" }}>
+          <div style={{ background: "#222", padding: "15px", borderRadius: "8px", border: "1px solid #444", opacity: selectedMap ? 1 : 0.5, pointerEvents: selectedMap ? "auto" : "none", display: "flex", flexDirection: "column", maxHeight: "520px" }}>
             <h4 style={{ color: "#f65dfb", fontSize: "12px", textTransform: "uppercase", marginBottom: "10px" }}>Team Selection</h4>
             <div style={{ display: "flex", gap: "10px", padding: "5px", background: "#111", borderRadius: "6px", marginBottom: "15px" }}>
               <button onClick={() => setActiveTeam("ally")} style={{ flex: 1, padding: "8px 12px", background: activeTeam === "ally" ? "#007bff" : "transparent", color: "white", border: "none", borderRadius: "4px", cursor: "pointer", fontWeight: "bold" }}>Ally ({allyMarkers.length})</button>
@@ -654,7 +1012,7 @@ const TacMap: React.FC = () => {
                 const isOnCurrentTeam = (activeTeam === "ally" ? allyMarkers : enemyMarkers).some(m => m.heroName === asset.name);
                 return (
                   <div key={asset.asset_id} draggable={!!selectedMap && !isOnCurrentTeam} onDragStart={(e) => e.dataTransfer.setData("assetData", JSON.stringify(asset))} style={{ cursor: (selectedMap && !isOnCurrentTeam) ? "grab" : "not-allowed", textAlign: "center", padding: "5px", background: "#333", borderRadius: "4px", border: "1px solid #444", opacity: isOnCurrentTeam ? 0.3 : 1 }}>
-                    <img src={asset.image_path} alt={asset.name} style={{ width: "50px", height: "50px", borderRadius: "4px" }} />
+                    <img src={asset.image_path} alt={asset.name} style={{ width: "36px", height: "36px", borderRadius: "4px" }} />
                     <div style={{ fontSize: "10px", marginTop: "4px" }}>{asset.name}</div>
                   </div>
                 );
@@ -677,13 +1035,14 @@ const TacMap: React.FC = () => {
         style={{ flex: 1, display: "flex", backgroundColor: "#000000", position: "relative", minWidth: 0, justifyContent: "center", alignItems: "center", overflow: "hidden", cursor: spacePressed || isPanning ? "grabbing" : selectedMap ? "default" : "not-allowed" }}
       >
         <button
-          onClick={() => setSidebarOpen(!sidebarOpen)}
+          onClick={(e) => { e.stopPropagation(); setSidebarOpen(!sidebarOpen); }}
+          onMouseDown={(e) => e.stopPropagation()}
           style={{ position: "absolute", top: "20px", left: "10px", zIndex: 15, background: "linear-gradient(45deg, #e60082, #f65dfb)", border: "none", color: "white", borderRadius: "4px", width: "36px", height: "36px", cursor: "pointer", fontWeight: "bold", fontSize: "18px", display: "flex", alignItems: "center", justifyContent: "center", boxShadow: "0 4px 10px rgba(230, 0, 130, 0.3)" }}
         >
           {sidebarOpen ? "«" : "»"}
         </button>
 
-        <div style={{ 
+        <div onMouseDown={(e) => e.stopPropagation()} onClick={(e) => e.stopPropagation()} style={{ 
           position: "absolute", top: "20px", right: "10px", zIndex: 15, 
           display: "flex", flexDirection: "column", alignItems: "flex-end", gap: "10px" 
         }}>
@@ -710,6 +1069,33 @@ const TacMap: React.FC = () => {
           }}>
             {Math.round(zoom * 100)}%
           </div>
+
+          {selectedMap && (
+            <button
+              onClick={() => {
+                if (!isPlayByPlayOpen) {
+                  setIsPlayByPlayOpen(true);
+                  if (playSteps.length === 0) addPlayStep();
+                } else {
+                  setIsPlayByPlayOpen(false);
+                }
+              }}
+              title="Play-by-Play"
+              style={{
+                background: isPlayByPlayOpen
+                  ? "linear-gradient(45deg, #e60082, #f65dfb)"
+                  : "rgba(0,0,0,0.7)",
+                border: isPlayByPlayOpen ? "none" : "1px solid #555",
+                color: "white", borderRadius: "6px",
+                padding: "6px 12px", cursor: "pointer",
+                fontWeight: "bold", fontSize: "12px",
+                backdropFilter: "blur(4px)",
+                boxShadow: isPlayByPlayOpen ? "0 2px 10px rgba(246,93,251,0.4)" : "none"
+              }}
+            >
+              ▶ Play-by-Play {playSteps.length > 0 ? `(${playSteps.length})` : ""}
+            </button>
+          )}
         </div>
 
         <div 
@@ -736,15 +1122,27 @@ const TacMap: React.FC = () => {
                 key={marker.id}
                 style={{
                   position: "absolute", left: `${(marker.x / 1000) * 100}%`, top: `${(marker.y / 600) * 100}%`,
-                  width: "44px", height: "44px", borderRadius: "50%",
-                  border: selectedElement?.id === marker.id ? "3px solid #f65dfb" : `2px solid ${marker.team === "ally" ? "#007bff" : "#dc3545"}`,
-                  boxShadow: marker.team === "ally" ? "0 0 15px rgba(0, 123, 255, 0.5)" : "0 0 15px rgba(220, 53, 69, 0.5)",
+                  width: "15px", height: "15px", borderRadius: "50%",
+                  border: selectedElement?.id === marker.id || selectedMarkerIds.includes(marker.id) ? "3px solid #f65dfb" : `2px solid ${marker.team === "ally" ? "#007bff" : "#dc3545"}`,
+                  boxShadow: selectedMarkerIds.includes(marker.id) ? "0 0 15px rgba(246,93,251,0.6)" : marker.team === "ally" ? "0 0 15px rgba(0, 123, 255, 0.5)" : "0 0 15px rgba(220, 53, 69, 0.5)",
                   backgroundImage: `url(${marker.iconUrl})`, backgroundSize: "cover", transform: "translate(-50%, -50%)",
-                  zIndex: 10, cursor: activeTool === "select" ? "grab" : "default"
+                  zIndex: 10, cursor: activeTool === "select" ? "grab" : "default",
+                  transition: isAnimating ? "left 0.5s cubic-bezier(0.4,0,0.2,1), top 0.5s cubic-bezier(0.4,0,0.2,1)" : "none"
                 }}
                 onMouseDown={(e) => {
-                  if (activeTool === "select") {
-                    e.stopPropagation(); setSelectedElement({ type: "marker", id: marker.id }); setIsDraggingElement(true);
+                  if (activeTool !== "select") return;
+                  e.stopPropagation();
+                  const { x, y } = getCoords(e);
+                  if (selectedMarkerIds.includes(marker.id) && selectedMarkerIds.length > 1) {
+                    // Start group drag
+                    setIsDragSelectingGroup(true);
+                    setGroupDragStart({ x, y });
+                    setGroupOriginalPositions(markersRef.current.filter(m => selectedMarkerIds.includes(m.id)).map(m => ({ id: m.id, x: m.x, y: m.y })));
+                  } else {
+                    // Single marker drag
+                    setSelectedMarkerIds([]);
+                    setSelectedElement({ type: "marker", id: marker.id });
+                    setIsDraggingElement(true);
                   }
                 }}
               >
@@ -758,19 +1156,142 @@ const TacMap: React.FC = () => {
           </div>
         </div>
 
-        <div style={{ position: "absolute", bottom: "30px", left: "50%", transform: "translateX(-50%)", display: "flex", gap: "15px", background: "rgba(22, 22, 22, 0.9)", padding: "10px 20px", borderRadius: "12px", border: "1px solid #333", backdropFilter: "blur(10px)", zIndex: 20, boxShadow: "0 10px 30px rgba(0,0,0,0.5)", opacity: selectedMap ? 1 : 0.5, pointerEvents: selectedMap ? "auto" : "none" }}>
+        {/* Play-by-Play Panel */}
+        {isPlayByPlayOpen && selectedMap && (
+          <div onMouseDown={(e) => e.stopPropagation()} onClick={(e) => e.stopPropagation()} style={{
+            position: "absolute", bottom: "130px", left: "50%", transform: "translateX(-50%)",
+            background: "rgba(18, 18, 18, 0.97)", border: "1px solid #333",
+            borderRadius: "14px", padding: "14px 18px", zIndex: 20,
+            backdropFilter: "blur(12px)", boxShadow: "0 8px 32px rgba(0,0,0,0.6)",
+            display: "flex", flexDirection: "column", gap: "10px",
+            minWidth: "360px", maxWidth: "680px"
+          }}>
+            <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+              <span style={{ fontSize: "12px", fontWeight: "bold", color: "#f65dfb", textTransform: "uppercase", letterSpacing: "1px" }}>
+                Play-by-Play
+              </span>
+              <button
+                onClick={() => setIsPlayByPlayOpen(false)}
+                style={{ background: "transparent", border: "none", color: "#666", cursor: "pointer", fontSize: "16px", padding: "0 4px" }}
+              >✕</button>
+            </div>
+            <div style={{ display: "flex", gap: "8px", flexWrap: "wrap", alignItems: "center" }}>
+              {playSteps.map((step, i) => (
+                <div key={step.id} style={{ display: "flex", alignItems: "center", gap: "4px" }}>
+                  <button
+                    onClick={() => goToStep(i)}
+                    style={{
+                      padding: "6px 14px", borderRadius: "20px", border: "none", cursor: "pointer",
+                      fontWeight: "bold", fontSize: "13px",
+                      background: currentStepIndex === i
+                        ? "linear-gradient(45deg, #e60082, #f65dfb)"
+                        : "#2a2a2a",
+                      color: currentStepIndex === i ? "white" : "#aaa",
+                      boxShadow: currentStepIndex === i ? "0 2px 10px rgba(246,93,251,0.4)" : "none",
+                      transition: "all 0.15s"
+                    }}
+                  >
+                    {step.label}
+                  </button>
+                  <button
+                    onClick={() => deletePlayStep(i)}
+                    title="Delete step"
+                    style={{
+                      background: "transparent", border: "none", color: "#555", cursor: "pointer",
+                      fontSize: "13px", padding: "0 2px", lineHeight: 1
+                    }}
+                  >✕</button>
+                </div>
+              ))}
+              <button
+                onClick={addPlayStep}
+                title="Add step from current state"
+                style={{
+                  padding: "6px 12px", borderRadius: "20px",
+                  border: "1px dashed #555", background: "transparent",
+                  color: "#888", cursor: "pointer", fontSize: "13px", fontWeight: "bold"
+                }}
+              >+ Add Step</button>
+            </div>
+            {currentStepIndex !== null && playSteps[currentStepIndex] && (
+              <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+                <span style={{ fontSize: "11px", color: "#666" }}>Label:</span>
+                <input
+                  type="text"
+                  value={playSteps[currentStepIndex].label}
+                  onChange={(e) => renamePlayStep(currentStepIndex, e.target.value)}
+                  style={{
+                    background: "#1a1a1a", border: "1px solid #444", borderRadius: "4px",
+                    color: "white", padding: "4px 8px", fontSize: "12px", width: "160px"
+                  }}
+                />
+                <span style={{ fontSize: "11px", color: "#555", marginLeft: "auto" }}>
+                  Step {currentStepIndex + 1} of {playSteps.length}
+                </span>
+                <button
+                  disabled={currentStepIndex === 0}
+                  onClick={() => goToStep(currentStepIndex - 1)}
+                  style={{ background: "#222", border: "1px solid #444", color: currentStepIndex === 0 ? "#444" : "#aaa", borderRadius: "6px", width: "28px", height: "28px", cursor: currentStepIndex === 0 ? "not-allowed" : "pointer", fontSize: "14px" }}
+                >‹</button>
+                <button
+                  disabled={currentStepIndex === playSteps.length - 1}
+                  onClick={() => goToStep(currentStepIndex + 1)}
+                  style={{ background: "#222", border: "1px solid #444", color: currentStepIndex === playSteps.length - 1 ? "#444" : "#aaa", borderRadius: "6px", width: "28px", height: "28px", cursor: currentStepIndex === playSteps.length - 1 ? "not-allowed" : "pointer", fontSize: "14px" }}
+                >›</button>
+              </div>
+            )}
+          </div>
+        )}
+
+        <div onMouseDown={(e) => e.stopPropagation()} onClick={(e) => e.stopPropagation()} style={{ position: "absolute", bottom: "20px", left: "50%", transform: "translateX(-50%)", display: "flex", gap: "8px", background: "rgba(22, 22, 22, 0.9)", padding: "8px 14px", borderRadius: "12px", border: "1px solid #333", backdropFilter: "blur(10px)", zIndex: 20, boxShadow: "0 10px 30px rgba(0,0,0,0.5)", opacity: selectedMap ? 1 : 0.5, pointerEvents: selectedMap ? "auto" : "none", alignItems: "center" }}>
           <ToolButton name="select" icon={<SelectIcon />} activeTool={activeTool} onClick={setActiveTool} title="Select (S)" />
           <ToolButton name="pen" icon={<PenIcon />} activeTool={activeTool} onClick={setActiveTool} title="Pen (P)" />
+          <ToolButton name="line" icon={<LineIcon />} activeTool={activeTool} onClick={(t) => { setActiveTool(t); setLineStart(null); setLinePreview(null); }} title="Line (L)" />
+          <ToolButton name="arrow" icon={<ArrowIcon />} activeTool={activeTool} onClick={(t) => { setActiveTool(t); setLineStart(null); setLinePreview(null); }} title="Arrow Line" />
+          <ToolButton name="circle" icon={<CircleIcon />} activeTool={activeTool} onClick={(t) => { setActiveTool(t); setCircleStart(null); setCirclePreview(null); }} title="Circle / Ellipse" />
           <ToolButton name="eraser" icon={<EraserIcon />} activeTool={activeTool} onClick={setActiveTool} title="Eraser (E)" />
-          <div style={{ width: "1px", background: "#444", margin: "0 5px" }} />
-          <button onClick={handleUndo} disabled={historyIndex === 0} style={{ width: "50px", height: "50px", borderRadius: "8px", border: "none", background: "#333", color: "white", cursor: historyIndex === 0 ? "not-allowed" : "pointer", opacity: historyIndex === 0 ? 0.5 : 1 }}><UndoIcon /></button>
-          <button onClick={handleRedo} disabled={historyIndex === history.length - 1} style={{ width: "50px", height: "50px", borderRadius: "8px", border: "none", background: "#333", color: "white", cursor: historyIndex === history.length - 1 ? "not-allowed" : "pointer", opacity: historyIndex === history.length - 1 ? 0.5 : 1 }}><RedoIcon /></button>
-          <div style={{ width: "1px", background: "#444", margin: "0 5px" }} />
-          <button onClick={deleteSelectedElement} disabled={!selectedElement} style={{ width: "50px", height: "50px", borderRadius: "8px", border: "none", background: selectedElement ? "#c4302b" : "#333", color: "white", cursor: selectedElement ? "pointer" : "not-allowed", opacity: selectedElement ? 1 : 0.5 }}><TrashIcon /></button>
+          <div style={{ width: "1px", background: "#444", margin: "0 3px", alignSelf: "stretch" }} />
+          <button onClick={handleUndo} disabled={historyIndex === 0} style={{ width: "40px", height: "40px", borderRadius: "8px", border: "none", background: "#333", color: "white", cursor: historyIndex === 0 ? "not-allowed" : "pointer", opacity: historyIndex === 0 ? 0.5 : 1, display: "flex", alignItems: "center", justifyContent: "center" }}><UndoIcon /></button>
+          <button onClick={handleRedo} disabled={historyIndex === history.length - 1} style={{ width: "40px", height: "40px", borderRadius: "8px", border: "none", background: "#333", color: "white", cursor: historyIndex === history.length - 1 ? "not-allowed" : "pointer", opacity: historyIndex === history.length - 1 ? 0.5 : 1, display: "flex", alignItems: "center", justifyContent: "center" }}><RedoIcon /></button>
+          <div style={{ width: "1px", background: "#444", margin: "0 3px", alignSelf: "stretch" }} />
+          <button onClick={deleteSelectedElement} disabled={!selectedElement && selectedMarkerIds.length === 0} style={{ width: "40px", height: "40px", borderRadius: "8px", border: "none", background: (selectedElement || selectedMarkerIds.length > 0) ? "#c4302b" : "#333", color: "white", cursor: (selectedElement || selectedMarkerIds.length > 0) ? "pointer" : "not-allowed", opacity: (selectedElement || selectedMarkerIds.length > 0) ? 1 : 0.5, display: "flex", alignItems: "center", justifyContent: "center" }}><TrashIcon /></button>
+          <div style={{ width: "1px", background: "#444", margin: "0 3px", alignSelf: "stretch" }} />
+          {/* Color wheel */}
+          <div style={{ position: "relative", display: "flex", alignItems: "center", justifyContent: "center" }} title="Drawing color">
+            <div style={{
+              width: "40px", height: "40px", borderRadius: "8px", background: "#333",
+              display: "flex", alignItems: "center", justifyContent: "center",
+              border: `3px solid ${drawColor}`, boxSizing: "border-box",
+              boxShadow: `0 0 8px ${drawColor}88`, cursor: "pointer", overflow: "hidden",
+              position: "relative"
+            }}>
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke={drawColor} strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                <circle cx="12" cy="12" r="10"/>
+                <path d="M12 2a10 10 0 0 1 0 20"/>
+                <path d="M2 12h20"/>
+              </svg>
+              <input
+                type="color"
+                value={drawColor}
+                onChange={(e) => setDrawColor(e.target.value)}
+                style={{
+                  position: "absolute", inset: 0, opacity: 0, cursor: "pointer",
+                  width: "100%", height: "100%", border: "none", padding: 0
+                }}
+                title="Pick drawing color"
+              />
+            </div>
+          </div>
         </div>
 
-        {activeTool === "pen" && (
-          <div style={{ position: "absolute", bottom: "100px", left: "50%", transform: "translateX(-50%)", background: "rgba(22, 22, 22, 0.95)", padding: "12px 20px", borderRadius: "30px", border: "1px solid #f65dfb", display: "flex", alignItems: "center", gap: "15px", zIndex: 25 }}>
+        {(activeTool === "pen" || activeTool === "line" || activeTool === "arrow" || activeTool === "circle") && (
+          <div onMouseDown={(e) => e.stopPropagation()} onClick={(e) => e.stopPropagation()} style={{ position: "absolute", bottom: isPlayByPlayOpen ? "280px" : "80px", left: "50%", transform: "translateX(-50%)", background: "rgba(22, 22, 22, 0.95)", padding: "10px 18px", borderRadius: "30px", border: "1px solid #f65dfb", display: "flex", alignItems: "center", gap: "12px", zIndex: 25, transition: "bottom 0.2s" }}>
+            {(activeTool === "line" || activeTool === "arrow") && lineStartRef.current && (
+              <span style={{ fontSize: "11px", color: "#f65dfb", fontWeight: "bold" }}>Click to place end point · ESC to cancel</span>
+            )}
+            {activeTool === "circle" && circleStartRef.current && (
+              <span style={{ fontSize: "11px", color: "#f65dfb", fontWeight: "bold" }}>Click to place opposite corner · ESC to cancel</span>
+            )}
              <span style={{ fontSize: "12px", fontWeight: "bold", color: "#f65dfb" }}>{brushSize}px</span>
              <input type="range" min="1" max="20" value={brushSize} onChange={(e) => setBrushSize(parseInt(e.target.value))} onMouseDown={() => setIsSlidingBrush(true)} onMouseUp={() => setIsSlidingBrush(false)} style={{ cursor: "pointer", accentColor: "#f65dfb" }} />
           </div>
@@ -828,9 +1349,13 @@ const TacMap: React.FC = () => {
           </div>
           <div style={{ flex: 1, overflowY: "auto", maxWidth: "1200px", width: "100%", margin: "0 auto" }}>
             {selectedMode ? (
-              <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(280px, 1fr))", gap: "25px", paddingBottom: "40px" }}>
-                {filteredMaps.map(m => (
-                  <div key={m.map_id} onClick={() => { setSelectedMap(m.name); setIsMapSelectorOpen(false); }} onMouseEnter={() => setHoveredMap(m)} onMouseLeave={() => setHoveredMap(null)} style={{ position: "relative", height: "160px", borderRadius: "12px", overflow: "hidden", cursor: "pointer", border: "2px solid #282828" }}>
+              <div key={modeAnimKey} style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(280px, 1fr))", gap: "25px", paddingBottom: "40px" }}>
+                {filteredMaps.map((m, idx) => (
+                  <div key={m.map_id} onClick={() => { setSelectedMap(m.name); setIsMapSelectorOpen(false); }} onMouseEnter={() => setHoveredMap(m)} onMouseLeave={() => setHoveredMap(null)}
+                    style={{ position: "relative", height: "160px", borderRadius: "12px", overflow: "hidden", cursor: "pointer", border: "2px solid #282828",
+                      animation: `mapCardPopIn 0.35s cubic-bezier(0.34,1.56,0.64,1) both`,
+                      animationDelay: `${idx * 50}ms`
+                    }}>
                     <div style={{ position: "absolute", top: 0, left: 0, width: "100%", height: "100%", backgroundImage: `url(${m.image_path})`, backgroundSize: "cover", backgroundPosition: "center", transition: "transform 0.5s ease", transform: hoveredMap?.map_id === m.map_id ? "scale(1.1)" : "scale(1)" }} />
                     <div style={{ position: "absolute", bottom: 0, left: 0, width: "100%", padding: "20px", background: "linear-gradient(transparent, rgba(0,0,0,0.9))", display: "flex", justifyContent: "space-between", alignItems: "flex-end" }}>
                       <span style={{ fontSize: "18px", fontWeight: "bold" }}>{m.name}</span>


### PR DESCRIPTION
Added a line tool in the toolbar 
Added a arrow head tool in the toolbar 
Added a sphere tool in the toolbar
Added the color wheel to the toolbar

Disabled the "Team Selection" buttons (ally and enemy) from having an assigned color to the drawing tool ( remove the ability for their color to be allowed to change the drawing tools color)
Added bubble animation map selection
team overview
Added the ability for the selection tool to be able to perform drag-select.

Fixed the bug where the step by step wasn't saving when saving the map
Made the hero icons when dropped on the map a little smaller (from 36px x 36pc to 15px x 15px)
